### PR TITLE
Make the module more generic

### DIFF
--- a/README-Original.md
+++ b/README-Original.md
@@ -1,0 +1,32 @@
+# UW Auth
+
+This module enables Drupal 8 to authenticate users using Shibboleth, and assign
+their roles based on group membership settings in Active Directory or in
+the UW Groups Web Service.
+
+Whenever a Shibboleth session is detected, the user is logged in as that user.
+Or, if the account doesn't exist, it'll be created automatically. There is no
+filtering of what users should be created. User accounts will be given the
+same user id, as their NetID. And, their email will be set to NETID@uw.edu.
+
+The module was designed and tested using Apache with mod_shib2. Shibboleth is
+configured to expose the attribute "uwnetid", which will be used as the
+visitors username.
+
+In order to enable the module, go to Manage > Extend > UW Auth. Once enabled,
+go to Manage > Configuration > People > UW Auth to configure.
+
+Finally, if no roles are mapped (or the user isn't assigned to any), they will
+be given the role of authenticated user.
+
+## Recommended Version
+
+For stable operation, please download or pull a specific tag (release).
+Otherwise you are likely to download the latest development code, which may
+or may not work right.
+
+## Federation
+
+There is no support for federated logins. The module assumes all
+users are using UW NetID's. This functionality may change in the future, if the
+need arises for it.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,70 @@
 # UW Auth
 
 This module enables Drupal 8 to authenticate users using Shibboleth, and assign
-their roles based on group membership settings in Active Directory or in
-the UW Groups Web Service.
+their roles based on information in other identity management systems.
+
+It is a fork of the module created by the University of Washington, to be found
+at [https://github.com/jtyocum/uwauth](https://github.com/jtyocum/uwauth), as 
+allowed by its GPL-3.0+ license, as provided in the `LICENSE.txt` file.
+
+The original `README.md file` has been renamed to `README-Original.md`.
+
+
+## Operation
 
 Whenever a Shibboleth session is detected, the user is logged in as that user.
 Or, if the account doesn't exist, it'll be created automatically. There is no
 filtering of what users should be created. User accounts will be given the
-same user id, as their NetID. And, their email will be set to NETID@uw.edu.
+same user name, as their Shibboleth `NameID`.
 
-The module was designed and tested using Apache with mod_shib2. Shibboleth is
-configured to expose the attribute "uwnetid", which will be used as the
-visitors username.
+The module was designed and tested using Apache with `mod_shib_24`. 
 
-In order to enable the module, go to Manage > Extend > UW Auth. Once enabled,
-go to Manage > Configuration > People > UW Auth to configure.
 
-Finally, if no roles are mapped (or the user isn't assigned to any), they will
-be given the role of authenticated user.
+### Assumptions 
 
+Shibboleth is assumed to be configured to expose:
+
+* `name` or `REDIRECT-name` : the Shibboleth `NameID`, typically set in 
+  `/etc/shibbolet/attribute-map.xml`.
+* `mail` or `REDIRECT-mail` : optional ; an e-mail address in string form.
+
+
+As per [https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPAttributeExtractor](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPAttributeExtractor) :
+_The name property corresponds to [...] the Format XML attribute of a SAML <NameID>[...] element._ 
+Such a mapping may look like this depending on your Shibboleth configuration:
+
+    <Attribute id="name"
+      name="urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified" />
+    
+    
+### Account creation and usage
+
+* new accounts are created on the fly
+  * if the `mail` value matches one of the allowed domains, that value is used 
+    for the user account `mail` and `init` base fields
+  * if that value exists, but does not belong to one of the allowed domains, the
+    value is used, _and_ the account is marked as blocked
+  * if the `mail` value is empty or missing, a pseudo-random address is 
+    generated _and_ the account is marked as blocked
+* for existing accounts:
+  * if the `mail` value matches, the account is used as such
+  * if the `mail` value does not match, the new value is used to update the
+    user account, and the change is logged for reference. The `init` field is
+    not updated.
+* in all cases, if the user did not have an active Drupal session, the `login` 
+  timestamp field on the user is updated.
+  
+    
 ## Recommended Version
 
 For stable operation, please download or pull a specific tag (release).
 Otherwise you are likely to download the latest development code, which may
 or may not work right.
 
+
 ## Federation
 
-There is no support for federated logins. The module assumes all
-users are using UW NetID's. This functionality may change in the future, if the
-need arises for it.
+There is no support for federated logins. The module assumes all users are using 
+centralized identifiers from the group's Shibboleth IdP. 
+
+This functionality may change in the future, if the need arises for it.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The module was designed and tested using Apache with `mod_shib_24`.
 Shibboleth is assumed to be configured to expose:
 
 * `name` or `REDIRECT-name` : the Shibboleth `NameID`, typically set in 
-  `/etc/shibbolet/attribute-map.xml`.
+  `/etc/shibboleth/attribute-map.xml`.
 * `mail` or `REDIRECT-mail` : optional ; an e-mail address in string form.
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,39 @@ Such a mapping may look like this depending on your Shibboleth configuration:
 * in all cases, if the user did not have an active Drupal session, the `login` 
   timestamp field on the user is updated.
   
-    
+
+## Installation
+
+In addition to enabling the module, you need to modify the `.htaccess` at the
+document root, or its equivalent in your vhost definition, to avoid having URLs
+needed by the Shibboleth SP being rewritten.
+
+Before:
+
+    # Pass all requests not referring directly to files in the filesystem to
+    # index.php.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} !=/favicon.ico
+    RewriteRule ^ index.php [L]
+
+After:
+
+    # Pass all requests not referring directly to files in the filesystem to
+    # index.php.
+    RewriteCond %{REQUEST_URI} !^/Shibboleth.sso
+    RewriteCond %{REQUEST_URI} !^/secure
+    RewriteCond %{REQUEST_URI} !^/shibboleth-sp
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} !=/favicon.ico
+    RewriteRule ^ index.php [L]
+
+Depending on the specifics of your SP configuration, you may want to tune these
+rules. The `/Shibboleth.sso` Shibboleth SP endpoint is configurable in the 
+module settings form at `/admin/config/people/uwauth`.
+
+
 ## Recommended Version
 
 For stable operation, please download or pull a specific tag (release).

--- a/config/install/uwauth.settings.yml
+++ b/config/install/uwauth.settings.yml
@@ -1,14 +1,17 @@
 group:
   source: none
 auth:
-  # The name of the server variable holding the Shibboleth NameID.
-  name_id: 'uid'
   allowed_attributes:
     - 'cn'
     - 'employeeType'
     - 'givenName'
     - 'sn'
     - 'uid'
+  excluded_routes:
+    - 'user.login'
+    - 'user.logout'
+  name_id: 'uid'
+  sp_endoint: '/Shibboleth.sso'
 mail:
   # An array of valid email domains. If empty, any domain is valid.
   valid_domains: []

--- a/config/install/uwauth.settings.yml
+++ b/config/install/uwauth.settings.yml
@@ -13,5 +13,5 @@ auth:
   name_id: 'uid'
   sp_endoint: '/Shibboleth.sso'
 mail:
-  # An array of valid email domains. If empty, any domain is valid.
-  valid_domains: []
+  valid_domains:
+    - 'uw.edu'

--- a/config/install/uwauth.settings.yml
+++ b/config/install/uwauth.settings.yml
@@ -1,2 +1,5 @@
 group:
   source: none
+mail:
+  # An array of valid email domains. If empty, any domain is valid.
+  valid_domains: []

--- a/config/install/uwauth.settings.yml
+++ b/config/install/uwauth.settings.yml
@@ -1,5 +1,14 @@
 group:
   source: none
+auth:
+  # The name of the server variable holding the Shibboleth NameID.
+  name_id: 'uid'
+  allowed_attributes:
+    - 'cn'
+    - 'employeeType'
+    - 'givenName'
+    - 'sn'
+    - 'uid'
 mail:
   # An array of valid email domains. If empty, any domain is valid.
   valid_domains: []

--- a/config/schema/uwauth.schema.yml
+++ b/config/schema/uwauth.schema.yml
@@ -2,6 +2,36 @@
 uwauth.settings:
   type: config_object
   mapping:
+    auth:
+      type: 'mapping'
+      label: 'Authentication-related settings'
+      mapping:
+        allowed_attributes:
+          type: 'sequence'
+          label: 'Attributes passed from the SP to Drupal'
+          nullable: true
+          sequence:
+            type: 'string'
+            label: 'Attribute/variable'
+            translatable: false
+        excluded_routes:
+          type: 'sequence'
+          label: 'Routes not using SSO, to support local login when not using group mapping'
+          nullable: true
+          sequence:
+            type: 'string'
+            label: 'Route name'
+            translatable: false
+        name_id:
+          type: 'string'
+          label: 'Attribute or variable mapped to the Shibboleth NameID'
+          nullable: false
+          translatable: false
+        sp_endoint:
+          type: 'string'
+          label: 'Path used by the Shibboleth SP endpoint'
+          nullable: false
+          translatable: false
     group:
       type: 'mapping'
       label: 'Groups'

--- a/config/schema/uwauth.schema.yml
+++ b/config/schema/uwauth.schema.yml
@@ -1,0 +1,23 @@
+# Schema for the configuration files of uwauth module.
+uwauth.settings:
+  type: config_object
+  mapping:
+    group:
+      type: 'mapping'
+      label: 'Groups'
+      mapping:
+        source:
+          type: 'string'
+          label: 'Source'
+    mail:
+      label: 'E-mail settings'
+      type: 'mapping'
+      mapping:
+        valid_domains:
+          type: 'sequence'
+          label: 'Valid email domains'
+          nullable: true
+          sequence:
+            type: 'string'
+            label: 'Domain'
+            translatable: false

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -4,6 +4,7 @@ namespace Drupal\uwauth\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
+use Drupal\uwauth\Form\UwAuthSettingsForm;
 
 /**
  * Class LogoutController contains the overridden controller for user.logout.
@@ -13,6 +14,11 @@ class LogoutController extends ControllerBase {
   /**
    * The overridden controller for user.logout.
    *
+   * Do not set the refrehs delay to 0 to avoid having an immediate redirect
+   * without page display.
+   *
+   * @see https://www.w3.org/TR/WCAG20-TECHS/H76.html
+   *
    * @return array
    *   A render array.
    */
@@ -20,10 +26,11 @@ class LogoutController extends ControllerBase {
     $title = $this->t('Logout');
     $frontUrl = Url::fromRoute('<front>', [], ['absolute' => TRUE]);
     $frontString = $frontUrl->toString();
-    $spLogoutUrl = Url::fromUri($frontUrl->toString() . 'Shibboleth.sso/Logout');
+    $spEndpoint = $this->config(UwAuthSettingsForm::SETTINGS_NAME)->get('auth.sp_endpoint');
+    $spLogoutUrl = Url::fromUri($frontUrl->toString() . ltrim("$spEndpoint/Logout", '/'));
     $spLogoutString = $spLogoutUrl->toString();
 
-    $message = $this->t('Logging out of OCEA and Shibboleth IdP');
+    $message = $this->t('Logging out of application and Shibboleth IdP');
 
     $ret['#attached']['html_head'][] = [
       [
@@ -32,7 +39,7 @@ class LogoutController extends ControllerBase {
         '#noscript' => FALSE,
         '#attributes' => [
           'http-equiv' => 'Refresh',
-          'content' => '0; URL=' . $frontString,
+          'content' => '1; URL=' . $frontString,
         ],
       ],
       'shibboleth-logout-redirect',

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\uwauth\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+
+/**
+ * Class LogoutController contains the overridden controller for user.logout.
+ */
+class LogoutController extends ControllerBase {
+
+  /**
+   * The overridden controller for user.logout.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function logout() {
+    $title = $this->t('Logout');
+    $frontUrl = Url::fromRoute('<front>', [], ['absolute' => TRUE]);
+    $frontString = $frontUrl->toString();
+    $spLogoutUrl = Url::fromUri($frontUrl->toString() . 'Shibboleth.sso/Logout');
+    $spLogoutString = $spLogoutUrl->toString();
+
+    $message = $this->t('Logging out of OCEA and Shibboleth IdP');
+
+    $ret['#attached']['html_head'][] = [
+      [
+        // Redirect through a 'Refresh' meta tag.
+        '#tag' => 'meta',
+        '#noscript' => FALSE,
+        '#attributes' => [
+          'http-equiv' => 'Refresh',
+          'content' => '0; URL=' . $frontString,
+        ],
+      ],
+      'shibboleth-logout-redirect',
+    ];
+
+    $ret['title'] = [
+      '#markup' => "<h1>$title</h1>",
+    ];
+    $ret['message'] = [
+      '#markup' => "<p>$message</p>",
+    ];
+    $ret['main'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'iframe',
+      '#attributes' => [
+        'src' => $spLogoutString,
+        'style' => 'visibility: hidden',
+      ],
+    ];
+    user_logout();
+    return $ret;
+  }
+
+}

--- a/src/Controller/UwAuthLogoutController.php
+++ b/src/Controller/UwAuthLogoutController.php
@@ -1,22 +1,21 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\uwauth\Controller\UwAuthLogoutController.
- */
-
 namespace Drupal\uwauth\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 
+/**
+ * Class UwAuthLogoutController contains the controller for SSO logout.
+ */
 class UwAuthLogoutController extends ControllerBase {
+
   /**
-  * Log user out of Drupal, and redirect to weblogin
-  */
+   * Log user out of Drupal, and redirect to web login.
+   */
   public function logout() {
     user_logout();
     return new TrustedRedirectResponse('https://weblogin.washington.edu/');
   }
+
 }
-?>

--- a/src/Debug.php
+++ b/src/Debug.php
@@ -4,10 +4,19 @@ namespace Drupal\uwauth;
 
 use Drupal\Component\Utility\Unicode;
 
+/**
+ * Class Debug provides configurable debug information.
+ */
 class Debug {
 
   protected $verbose;
 
+  /**
+   * Debug constructor.
+   *
+   * @param bool $verbose
+   *   Display debug information ?
+   */
   public function __construct($verbose = FALSE) {
     $this->verbose = $verbose;
   }

--- a/src/Debug.php
+++ b/src/Debug.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\uwauth;
 
-
 use Drupal\Component\Utility\Unicode;
 
 class Debug {

--- a/src/Debug.php
+++ b/src/Debug.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\uwauth;
+
+
+use Drupal\Component\Utility\Unicode;
+
+class Debug {
+
+  protected $verbose;
+
+  public function __construct($verbose = FALSE) {
+    $this->verbose = $verbose;
+  }
+
+  /**
+   * Display diagnostic information if enabled.
+   *
+   * @param string $message
+   *   The message to display.
+   * @param string $level
+   *   The message severity level.
+   */
+  public function message($message, $level = 'status') {
+    if (!$this->verbose) {
+      return;
+    }
+    $stack = debug_backtrace(TRUE, 2);
+    $caller = $stack[1];
+    $class = empty($caller['class']) ? NULL : $caller['class'];
+    $function = $caller['function'];
+    if (!empty($class)) {
+      $classArray = explode('\\', $class);
+      $shortClassArray = [];
+      $len = count($classArray);
+      for ($i = 0; $i < $len - 1; $i++) {
+        $shortClassArray[$i] = Unicode::substr($classArray[$i], 0, 1);
+      }
+      $shortClassArray[$len - 1] = $classArray[$len - 1];
+      $shortClass = implode('\\', $shortClassArray);
+    }
+    else {
+      $shortClass = '';
+    }
+
+    $message = ($shortClass ? "$shortClass::$function" : $function) . " $message";
+
+    drupal_set_message($message, $level);
+  }
+
+}

--- a/src/EventSubscriber/LogoutOverride.php
+++ b/src/EventSubscriber/LogoutOverride.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\uwauth\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class LogoutOverride alters the user.logout route to logout from Shibboleth.
+ */
+class LogoutOverride extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    if (!$route = $collection->get('user.logout')) {
+      return;
+    }
+
+    $route->setDefault('_controller', '\Drupal\uwauth\Controller\LogoutController::logout');
+  }
+
+}

--- a/src/EventSubscriber/UwAuthSubscriber.php
+++ b/src/EventSubscriber/UwAuthSubscriber.php
@@ -1,18 +1,17 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\uwauth\EventSubscriber\UwAuthSubscriber.
- */
-
 namespace Drupal\uwauth\EventSubscriber;
 
-use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\PageCache\ResponsePolicy\KillSwitch;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\user\Entity\User;
-use Drupal\Core\Entity\EntityManagerInterface;
-use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\LocalRedirectResponse;
+use Drupal\user\UserInterface;
 use Drupal\uwauth\Debug;
+use Drupal\uwauth\Form\UwAuthSettingsForm;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
@@ -23,20 +22,35 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  * UW Auth event subscriber.
  */
 class UwAuthSubscriber implements EventSubscriberInterface {
+  use StringTranslationTrait;
+
+  /**
+   * The current_user service.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
 
   /**
    * A diagnostic display service.
    *
    * @var \Drupal\uwauth\Debug
    */
-  public $debug;
+  protected $debug;
 
   /**
    * The entity manager.
    *
-   * @var \Drupal\Core\Entity\EntityManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entityManager;
+  protected $entityTypeManager;
+
+  /**
+   * The page_cache_kill_switch service.
+   *
+   * @var \Drupal\Core\PageCache\ResponsePolicy\KillSwitch
+   */
+  protected $killSwitch;
 
   /**
    * The request.
@@ -46,20 +60,41 @@ class UwAuthSubscriber implements EventSubscriberInterface {
   protected $requestStack;
 
   /**
+   * The module settings.
+   *
+   * @var array|mixed|null
+   */
+  protected $settings;
+
+  /**
    * Constructs a UW Auth event subscriber.
    *
-   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    *   The request.
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
    *   The entity manager service.
    * @param \Drupal\uwauth\Debug $debug
    *   A diagnostic display service.
+   * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
+   *   The current user.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   The config.factory service.
+   * @param \Drupal\Core\PageCache\ResponsePolicy\KillSwitch $killSwitch
+   *   The page_cache_kill_switch service.
    */
-  public function __construct(RequestStack $request_stack, EntityManagerInterface $entity_manager,
-    Debug $debug) {
+  public function __construct(
+    RequestStack $requestStack,
+    EntityTypeManagerInterface $entity_manager,
+    Debug $debug,
+    AccountProxyInterface $currentUser,
+    ConfigFactoryInterface $config,
+    KillSwitch $killSwitch) {
     $this->debug = $debug;
-    $this->entityManager = $entity_manager;
-    $this->requestStack = $request_stack;
+    $this->entityTypeManager = $entity_manager;
+    $this->requestStack = $requestStack;
+    $this->currentUser = $currentUser;
+    $this->settings = $config->get(UwAuthSettingsForm::SETTINGS_NAME);
+    $this->killSwitch = $killSwitch;
   }
 
   /**
@@ -74,20 +109,20 @@ class UwAuthSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public function handle(GetResponseEvent $event) {
-    $this->debug->message("user id: " . \Drupal::currentUser()->id());
-    if (\Drupal::currentUser()->isAuthenticated()) {
-      $this->debug->message('Already authenticated');
+    $this->debug->message($this->t('User id: @id', ['@id' => $this->currentUser->id()]));
+    if ($this->currentUser->isAuthenticated()) {
+      $this->debug->message($this->t('Already authenticated'));
       return;
     }
-    $this->debug->message('Not authenticated');
+    $this->debug->message($this->t('Not authenticated'));
 
-    // Only handle requests if a group source is configured
-    $group_source = \Drupal::config('uwauth.settings')->get('group.source');
+    // Only handle requests if a group source is configured.
+    $group_source = $this->settings->get('group.source');
     if ($group_source === "none") {
       $this->debug->message("Group source: 'none'.");
       return;
     }
-    $this->debug->message("Group source '$group_source'.");
+    $this->debug->message($this->t("Group source '@source'.", ['@source' => $group_source]));
 
     // Verify we're actually in a Shibboleth session.
     $shib_session_id = $this->requestStack
@@ -96,10 +131,10 @@ class UwAuthSubscriber implements EventSubscriberInterface {
       ->get('REDIRECT_Shib-Session-ID');
 
     if (!isset($shib_session_id)) {
-      $this->debug->message('Not in a Shibboleth session.');
+      $this->debug->message($this->t('Not in a Shibboleth session.'));
       return;
     }
-    $this->debug->message("In Shibboleth session $shib_session_id.");
+    $this->debug->message($this->t("In Shibboleth session @id.", ['@id' => $shib_session_id]));
 
     // Check for a UW NetID from Shibboleth.
     $attributes = new AttributeBag();
@@ -114,50 +149,57 @@ class UwAuthSubscriber implements EventSubscriberInterface {
     foreach ($attributeCandidates as $k => $v) {
       $matches = [];
       if (preg_match('/^(REDIRECT_)?Shib-([-\w]+)/', $k, $matches)) {
-        $this->debug->message("Shibboleth " . $matches[2] . ' = ' . json_encode($v));
+        $this->debug->message($this->t('Shibboleth @name = @value.', [
+          '@name' => $matches[2],
+          '@value' => json_encode($v),
+        ]));
       }
       elseif (preg_match('/^REDIRECT_([\w]+)$/', $k, $matches)) {
         $name = $matches[1];
         if (isset($allowedAttributes[$name])) {
-          $this->debug->message("Attribute $name = " . json_encode($v));
+          $this->debug->message($this->t('Attribute @name = @value.', [
+            '@name' => $name,
+            '@value' => json_encode($v),
+          ]));
           $attributes->set($name, $v);
         }
       }
     }
     $username = $attributes->get('uid');
+
     if (!isset($username)) {
       return;
     }
 
-    $this->login_user();
-    $event->setResponse($this->redirect_user());
+    $this->loginUser();
+    $event->setResponse($this->redirectUser());
   }
 
   /**
    * Authenticate user, and log them in.
    */
-  private function login_user() {
+  private function loginUser() {
     $username = $this->requestStack->getCurrentRequest()->server->get('REDIRECT_uid');
-    $accounts = $this->entityManager->getStorage('user')->loadByProperties(array('name' => $username));
+    $accounts = $this->entityTypeManager->getStorage('user')->loadByProperties(['name' => $username]);
     $account = reset($accounts);
 
-    // Create account if necessary
+    // Create account if necessary.
     if (!$account) {
-      $user = User::create(array(
+      $user = User::create([
         'name' => $username,
-        'mail' => $username.'@uw.edu',
-        'status' => 1
-      ));
-      $user->setPassword(substr(password_hash(openssl_random_pseudo_bytes(8), PASSWORD_DEFAULT),rand(4, 16),32));
+        'mail' => $username . '@uw.edu',
+        'status' => 1,
+      ]);
+      $user->setPassword(substr(password_hash(openssl_random_pseudo_bytes(8), PASSWORD_DEFAULT), rand(4, 16), 32));
       $user->save();
     }
 
-    // Set cookie_lifetime to on browser close
+    // Set cookie_lifetime to on browser close.
     ini_set('session.cookie_lifetime', 0);
 
-    // Sync roles, and reload the modified user object
-    $this->sync_roles($account);
-    $accounts = $this->entityManager->getStorage('user')->loadByProperties(array('name' => $username));
+    // Sync roles, and reload the modified user object.
+    $this->syncRoles($account);
+    $accounts = $this->entityTypeManager->getStorage('user')->loadByProperties(['name' => $username]);
     $account = reset($accounts);
     user_login_finalize($account);
 
@@ -165,35 +207,35 @@ class UwAuthSubscriber implements EventSubscriberInterface {
   }
 
   /**
-  * Redirect user back to the requested page
-  */
-  private function redirect_user() {
-    // Disable Page Cache to prevent redirect response from being cached
-    \Drupal::service('page_cache_kill_switch')->trigger();
+   * Redirect user back to the requested page.
+   */
+  private function redirectUser() {
+    // Disable Page Cache to prevent redirect response from being cached.
+    $this->killSwitch->trigger();
     $current_uri = $this->requestStack->getCurrentRequest()->getRequestUri();
     $redirect = LocalRedirectResponse::create($current_uri);
     return $redirect;
   }
 
   /**
-   * Synchronize roles with UW Groups or Active Directory
+   * Synchronize roles with UW Groups or Active Directory.
    *
-   * @param $account
+   * @param \Drupal\user\UserInterface $account
    *   A user object.
    */
-  private function sync_roles($account) {
+  private function syncRoles(UserInterface $account) {
     $roles_existing = user_roles(TRUE);
     $roles_assigned = $account->getRoles(TRUE);
-    $mapped_roles = $this->map_groups_roles($account);
+    $mapped_roles = $this->mapGroupsRoles($account);
 
-    // Remove from roles they are no longer assigned to
-    foreach($roles_assigned as $rid_assigned => $role_assigned) {
+    // Remove from roles they are no longer assigned to.
+    foreach ($roles_assigned as $role_assigned) {
       if (!in_array($role_assigned, $mapped_roles)) {
         $account->removeRole($role_assigned);
       }
     }
 
-    // Add to newly assigned roles
+    // Add to newly assigned roles.
     foreach ($mapped_roles as $mapped) {
       if (array_key_exists($mapped, $roles_existing)) {
         $account->addRole($mapped);
@@ -204,33 +246,38 @@ class UwAuthSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Map UW Groups or AD group membership to roles
+   * Map UW Groups or AD group membership to roles.
    *
-   * @param $account
+   * @param \Drupal\user\UserInterface $account
    *   A user object.
+   *
+   * @return array<string>
+   *   An array of role names.
    */
-  private function map_groups_roles($account) {
-    switch (\Drupal::config('uwauth.settings')->get('group.source')) {
-      case "gws":
-        $group_membership = $this->fetch_gws_groups($account);
+  private function mapGroupsRoles(UserInterface $account) {
+    switch ($this->settings->get('group.source')) {
+      case 'gws':
+        $group_membership = $this->fetchGwsGroups($account);
         break;
-      case "ad":
-        $group_membership = $this->fetch_ad_groups($account);
+
+      case 'ad':
+        $group_membership = $this->fetchAdGroups($account);
         break;
     }
 
-    // Group to Role maps are stored as a multi-line string, containing pipe delimited key-value pairs
+    // Group to Role maps are stored as a multi-line string, containing pipe-
+    // delimited key-value pairs.
     $group_role_map = array();
-    foreach (preg_split("/((\r?\n)|(\r\n?))/", \Drupal::config('uwauth.settings')->get('group.map')) as $entry) {
+    foreach (preg_split("/((\r?\n)|(\r\n?))/", $this->settings->get('group.map')) as $entry) {
       $pair = explode('|', $entry);
-      $group_role_map[(string)$pair[0]] = (string)$pair[1];
+      $group_role_map[(string) $pair[0]] = (string) $pair[1];
     }
 
-    // Loop through group list, and extract matching roles
+    // Loop through group list, and extract matching roles.
     $mapped_roles = array();
     foreach ($group_membership as $group) {
       if (array_key_exists($group, $group_role_map)) {
-        $mapped_roles[] = (string)$group_role_map[$group];
+        $mapped_roles[] = (string) $group_role_map[$group];
       }
     }
 
@@ -238,74 +285,77 @@ class UwAuthSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Fetch group membership from UW Groups
+   * Fetch group membership from UW Groups.
    *
-   * @param $account
+   * @param \Drupal\user\UserInterface $account
    *   A user object.
+   *
+   * @return array<string>
+   *   An array of group names.
    */
-  private function fetch_gws_groups($account) {
-    return [];
-    $username = $account->getUsername();
+  private function fetchGwsGroups(UserInterface $account) {
 
-    $uwauth_config = \Drupal::config('uwauth.settings');
+    $username = $account->getAccountName();
 
-    // UW GWS URL
+    // UW GWS URL.
     $uwgws_url = 'https://iam-ws.u.washington.edu/group_sws/v1/search?member=' . $username . '&type=effective&scope=all';
 
-    // Query UW GWS for group membership
+    // Query UW GWS for group membership.
     $uwgws = curl_init();
-    curl_setopt_array($uwgws, array(
-                                CURLOPT_RETURNTRANSFER => TRUE,
-                                CURLOPT_FOLLOWLOCATION => TRUE,
-                                CURLOPT_SSLCERT        => $uwauth_config->get('gws.cert'),
-                                CURLOPT_SSLKEY         => $uwauth_config->get('gws.key'),
-                                CURLOPT_CAINFO         => $uwauth_config->get('gws.cacert'),
-                                CURLOPT_URL            => $uwgws_url,
-                                ));
+    curl_setopt_array($uwgws, [
+      CURLOPT_RETURNTRANSFER => TRUE,
+      CURLOPT_FOLLOWLOCATION => TRUE,
+      CURLOPT_SSLCERT        => $this->settings->get('gws.cert'),
+      CURLOPT_SSLKEY         => $this->settings->get('gws.key'),
+      CURLOPT_CAINFO         => $this->settings->get('gws.cacert'),
+      CURLOPT_URL            => $uwgws_url,
+    ]);
     $uwgws_response = curl_exec($uwgws);
     curl_close($uwgws);
 
-    // Extract groups from response
+    // Extract groups from response.
     $uwgws_feed = simplexml_load_string(str_replace('xmlns=', 'ns=', $uwgws_response));
     $uwgws_entries = $uwgws_feed->xpath("//a[@class='name']");
     $uwgws_groups = array();
-    foreach($uwgws_entries as $uwgws_entry) {
-      $uwgws_groups[] = (string)$uwgws_entry[0];
+    foreach ($uwgws_entries as $uwgws_entry) {
+      $uwgws_groups[] = (string) $uwgws_entry[0];
     }
 
     return $uwgws_groups;
   }
 
   /**
-   * Fetch group membership from Active Directory
+   * Fetch group membership from Active Directory.
    *
-   * @param $account
+   * @param \Drupal\user\UserInterface $account
    *   A user object.
+   *
+   * @return array
+   *   An array of group names.
    */
-  private function fetch_ad_groups($account) {
-    $username = $account->getUsername();
+  private function fetchAdGroups(UserInterface $account) {
+    $username = $account->getAccountName();
 
-    $uwauth_config = \Drupal::config('uwauth.settings');
-
-    // Search Filter
+    // Search Filter.
     $search_filter = "(sAMAccountName=" . $username . ")";
 
-    // Query Active Directory for user, and fetch group membership
-    $ad_conn = ldap_connect($uwauth_config->get('ad.uri'));
-    if(($uwauth_config->get('ad.binddn') !== NULL) && ($uwauth_config->get('ad.bindpass') !== NULL)) {
-      ldap_bind($ad_conn, $uwauth_config->get('ad.binddn'), $uwauth_config->get('ad.bindpass'));
+    // Query Active Directory for user, and fetch group membership.
+    $ad_conn = ldap_connect($this->settings->get('ad.uri'));
+    if (($this->settings->get('ad.binddn') !== NULL) && ($this->settings->get('ad.bindpass') !== NULL)) {
+      ldap_bind($ad_conn, $this->settings->get('ad.binddn'), $this->settings->get('ad.bindpass'));
     }
-    $ad_search = ldap_search($ad_conn, $uwauth_config->get('ad.basedn'), $search_filter, array('memberOf'));
+    $ad_search = ldap_search($ad_conn, $this->settings->get('ad.basedn'), $search_filter, ['memberOf']);
     $ad_search_results = ldap_get_entries($ad_conn, $ad_search);
 
-    // Extract group names from DNs
-    $ad_groups = array();
-    foreach($ad_search_results[0]['memberof'] as $entry) {
-      if(preg_match("/^CN=([a-zA-Z0-9_\- ]+)/", $entry, $matches)) {
-        $ad_groups[] = (string)$matches[1];
+    // Extract group names from DNs.
+    $ad_groups = [];
+    foreach ($ad_search_results[0]['memberof'] as $entry) {
+      if (preg_match("/^CN=([a-zA-Z0-9_\- ]+)/", $entry, $matches)) {
+        $ad_groups[] = (string) $matches[1];
       }
     }
 
     return $ad_groups;
   }
+
 }

--- a/uwauth.links.menu.yml
+++ b/uwauth.links.menu.yml
@@ -1,6 +1,6 @@
 uwauth.settings:
-  title: 'UW Auth'
+  title: 'Shibboleth'
   parent: user.admin_index
   description: 'Configure group membership sources, and group to role maps.'
   weight: -10
-  route_name: uwauth.settings 
+  route_name: uwauth.settings

--- a/uwauth.module
+++ b/uwauth.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * A Shibboleth and UW Groups authentication module. 
+ * A Shibboleth and UW Groups authentication module.
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -22,7 +22,7 @@ function uwauth_help($route_name, RouteMatchInterface $route_match) {
       $output .= '<h3>' . t('Groups Web Service') . '</h3>';
       $output .= '<p>' . t('GWS offers a centralized system for managing user groups at UW. In order to utilize it, you will need a certificate issued by UW CA to authenticate your application with the web service. This certificate is different from the InCommon certificate issued for web servers.') . '</p>';
       $output .= '<h3>' . t('Active Directory') . '</h3>';
-      $output .= '<p>' . t(' With AD, you can utilize either NETID or a departmental AD infrastructure. Both authenticated, and anonymous binds are supported. It is recommended that you use LDAPS whenever possible, and it is required when using NETID. You may need to configure OpenLDAP to load the required CA certificates, if using LDAPS.') . '</p>';
+      $output .= '<p>' . t('With AD, you can utilize either NETID or a departmental AD infrastructure. Both authenticated, and anonymous binds are supported. It is recommended that you use LDAPS whenever possible, and it is required when using NETID. You may need to configure OpenLDAP to load the required CA certificates, if using LDAPS.') . '</p>';
       $output .= '<h3>' . t('Group to Role Mapping') . '</h3>';
       $output .= '<p>' . t('For portability purposes, externally managed groups are mapped to Drupal roles. This mapping function allows for changes in group names, and sources without having to change permissions within Drupal.') . '</p>';
       $output .= '<p>' . t('Each row within the text box represents a group to role map entry. A group can only be mapped to a single role, as the group name is used as an internal identifier. Groups cannot be mapped to builtin Drupal roles. So, if you want to give a group, admin privileges, you will need to create a role with those privileges.') . '</p>';

--- a/uwauth.routing.yml
+++ b/uwauth.routing.yml
@@ -2,7 +2,7 @@ uwauth.settings:
   path: '/admin/config/people/uwauth'
   defaults:
     _form: '\Drupal\uwauth\Form\UwAuthSettingsForm'
-    _title: 'UW Auth'
+    _title: 'Shibboleth - UW Auth'
   requirements:
     _permission: 'administer site configuration'
 uwauth.logout:

--- a/uwauth.routing.yml
+++ b/uwauth.routing.yml
@@ -1,7 +1,7 @@
 uwauth.settings:
   path: '/admin/config/people/uwauth'
   defaults:
-    _form: '\Drupal\uwauth\UwAuthSettingsForm'
+    _form: '\Drupal\uwauth\Form\UwAuthSettingsForm'
     _title: 'UW Auth'
   requirements:
     _permission: 'administer site configuration'

--- a/uwauth.services.yml
+++ b/uwauth.services.yml
@@ -11,6 +11,7 @@ services:
       - '@current_user'
       - '@config.factory'
       - '@page_cache_kill_switch'
+      - '@current_route_match'
     tags:
       - { name: event_subscriber }
 

--- a/uwauth.services.yml
+++ b/uwauth.services.yml
@@ -1,10 +1,14 @@
 parameters:
-  uwauth.verbose: false
   uwauth.channel: 'uwauth'
+  uwauth.severity:
+    ad_sync: 'debug'
+    gws_sync: 'debug'
+    local_sync: 'debug'
+  uwauth.verbose: false
 
 services:
   logger.channel.uwauth:
-    parent: logger.channel_base
+    parent: 'logger.channel_base'
     arguments: ['%uwauth.channel%']
 
   uwauth.eventsubscriber:
@@ -17,6 +21,8 @@ services:
       - '@config.factory'
       - '@page_cache_kill_switch'
       - '@current_route_match'
+      - '@logger.channel.uwauth'
+      - '%uwauth.severity%'
     tags:
       - { name: event_subscriber }
 

--- a/uwauth.services.yml
+++ b/uwauth.services.yml
@@ -4,7 +4,13 @@ parameters:
 services:
   uwauth.eventsubscriber:
     class: Drupal\uwauth\EventSubscriber\UwAuthSubscriber
-    arguments: ['@request_stack', '@entity.manager', '@uwauth.debug']
+    arguments:
+      - '@request_stack'
+      - '@entity.manager'
+      - '@uwauth.debug'
+      - '@current_user'
+      - '@config.factory'
+      - '@page_cache_kill_switch'
     tags:
       - { name: event_subscriber }
 

--- a/uwauth.services.yml
+++ b/uwauth.services.yml
@@ -1,7 +1,12 @@
 parameters:
   uwauth.verbose: false
+  uwauth.channel: 'uwauth'
 
 services:
+  logger.channel.uwauth:
+    parent: logger.channel_base
+    arguments: ['%uwauth.channel%']
+
   uwauth.eventsubscriber:
     class: Drupal\uwauth\EventSubscriber\UwAuthSubscriber
     arguments:

--- a/uwauth.services.yml
+++ b/uwauth.services.yml
@@ -17,3 +17,8 @@ services:
   uwauth.debug:
     class: Drupal\uwauth\Debug
     arguments: ['%uwauth.verbose%']
+
+  uwauth.logout_override:
+    class: Drupal\uwauth\EventSubscriber\LogoutOverride
+    tags:
+      - { name: event_subscriber }

--- a/uwauth.services.yml
+++ b/uwauth.services.yml
@@ -1,6 +1,13 @@
+parameters:
+  uwauth.verbose: false
+
 services:
   uwauth.eventsubscriber:
     class: Drupal\uwauth\EventSubscriber\UwAuthSubscriber
-    arguments: ['@request_stack', '@entity.manager']
+    arguments: ['@request_stack', '@entity.manager', '@uwauth.debug']
     tags:
       - { name: event_subscriber }
+
+  uwauth.debug:
+    class: Drupal\uwauth\Debug
+    arguments: ['%uwauth.verbose%']


### PR DESCRIPTION
Hello and thanks for the module. We are using it in a project, so figured it would be better to make it more generic/flexible than the original version, than to remove its adaptation to the original UW needs.

This is what this PR does: it is expected to be usable at UW as a replacement for the original without needing more than some configuration, while supporting a different use case: SSO for identities, with locally maintained rights instead of remote group mapping, and many more configuration choices, defaulting to the prior UW values.
