### PR TITLE
loadMultiple does not index by rid like user_roles did

### DIFF
--- a/src/EventSubscriber/UwAuthSubscriber.php
+++ b/src/EventSubscriber/UwAuthSubscriber.php
@@ -492,7 +492,7 @@ class UwAuthSubscriber implements EventSubscriberInterface {
 
     // Add to newly assigned roles.
     foreach ($mapped_roles as $mapped) {
-      if (\array_key_exists($mapped, $roles_existing)) {
+      if (\in_array($mapped, $roles_existing)) {
         $account->addRole($mapped);
       }
     }


### PR DESCRIPTION
Fix bug with syncing roles due to deprecation of user_roles.